### PR TITLE
Add ShowUpDown property to Extenso.Windows.Forms.Controls.DataGridViewCalendarColumn

### DIFF
--- a/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarCell.cs
+++ b/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarCell.cs
@@ -56,6 +56,7 @@ public class DataGridViewCalendarCell : DataGridViewTextBoxCell
         var dataGridViewCalendarEditingControl = DataGridView.EditingControl as DataGridViewCalendarEditingControl;
 
         dataGridViewCalendarEditingControl.ShowCheckBox = (DataGridView.Columns[ColumnIndex] as DataGridViewCalendarColumn).ShowCheckBox;
+        dataGridViewCalendarEditingControl.ShowUpDown = (DataGridView.Columns[ColumnIndex] as DataGridViewCalendarColumn).ShowUpDown;
 
         try
         {

--- a/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarColumn.cs
+++ b/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarColumn.cs
@@ -45,10 +45,13 @@ public class DataGridViewCalendarColumn : DataGridViewColumn
 
     public bool ShowCheckBox { get; set; }
 
+    public bool ShowUpDown { get; set; }
+
     public override object Clone()
     {
         var dataGridViewCalendarColumn = (DataGridViewCalendarColumn)base.Clone();
         dataGridViewCalendarColumn.ShowCheckBox = this.ShowCheckBox;
+        dataGridViewCalendarColumn.ShowUpDown = this.ShowUpDown;
         dataGridViewCalendarColumn.dateTimePickerFormat = this.dateTimePickerFormat;
         dataGridViewCalendarColumn.customFormat = this.customFormat;
         return dataGridViewCalendarColumn;

--- a/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarEditingControl.cs
+++ b/Extenso.Windows.Forms/Controls/DataGridView/DataGridViewCalendarEditingControl.cs
@@ -32,7 +32,7 @@ internal class DataGridViewCalendarEditingControl : DateTimePicker, IDataGridVie
     public object EditingControlFormattedValue
     {
         get
-        { return this.Value.ToShortDateString(); }
+        { return this.Value.ToString("O"); }
         set
         {
             if (value is string)


### PR DESCRIPTION
Add ShowUpDown property to Extenso.Windows.Forms.Controls.DataGridViewCalendarColumn so that in combination with DateTimePickerFormat.Time the calendar column can be used to edit time only. Currently when setting DateTimePickerFormat.Time the calendar column shows the dropdown for the calendar to edit a date, which is not applicable with DateTimePickerFormat.Time